### PR TITLE
Add support for The Community Repo

### DIFF
--- a/repo_community_validation.txt
+++ b/repo_community_validation.txt
@@ -1,0 +1,1 @@
+community.repo.access: allow_forwarding_all


### PR DESCRIPTION
Adds this repository to [repo.community](https://repo.community).

(after merging this PR, still need to finish the instructions at https://repo.community/add)